### PR TITLE
feat: support configuring decorators

### DIFF
--- a/lib/python.ts
+++ b/lib/python.ts
@@ -137,13 +137,20 @@ const nodeHandlers = {
     ) {
       let [fields, imports] = listToPython(node.fields, config);
       let parentType = "";
+      let decorators = "";
 
       if (config.super) {
         parentType = `(${config.super})`;
       }
 
+      if (config.decorators?.length) {
+        decorators =
+          config.decorators.map((d) => d.replace(/^[^@]/m, "@$&")).join("\n") +
+          "\n";
+      }
+
       return [
-        `class ${node.name.value}${parentType}:
+        `${decorators}class ${node.name.value}${parentType}:
 ${indent}${fields.length ? fields.join(`\n${indent}`) : "pass"}`,
         imports,
       ];
@@ -154,13 +161,20 @@ ${indent}${fields.length ? fields.join(`\n${indent}`) : "pass"}`,
   ) {
     let [fields, imports] = listToPython(node.fields, config);
     let parentType = "";
+    let decorators = "";
 
     if (config.super) {
       parentType = `(${config.super})`;
     }
 
+    if (config.decorators?.length) {
+      decorators =
+        config.decorators.map((d) => d.replace(/^[^@]/m, "@$&")).join("\n") +
+        "\n";
+    }
+
     return [
-      `class ${node.name.value}${parentType}:
+      `${decorators}class ${node.name.value}${parentType}:
 ${indent}${fields.length ? fields.join(`\n${indent}`) : "pass"}`,
       imports,
     ];
@@ -234,6 +248,7 @@ const toPython = (node, config: FromSchemaConfig): [string | null, Imports] => {
 };
 
 export interface FromSchemaConfig {
+  decorators?: string[];
   super?: string;
   extraImports?: Record<string, string[]>;
   extraTypes?: Record<string, string>;

--- a/test/python/config.test.ts
+++ b/test/python/config.test.ts
@@ -51,6 +51,63 @@ class Hello(BaseModel):
     });
   });
 
+  describe("decorators", (): void => {
+    it(`Uses correct syntax when not specified`, async (): Promise<void> => {
+      const input = `
+    type Hello {
+      greeting: String!
+    }
+`;
+
+      const schema = makeExecutableSchema({ typeDefs: input });
+
+      expect(python.fromSchema(schema)).toEqual(`class Hello:
+    greeting: str`);
+    });
+
+    it(`Imports and displays callable syntax correctly`, async (): Promise<void> => {
+      const input = `
+    type Hello {
+      greeting: String!
+    }
+`;
+
+      const schema = makeExecutableSchema({ typeDefs: input });
+
+      expect(
+        python.fromSchema(schema, {
+          decorators: ["@dataclass(order=True)"],
+          extraImports: { dataclasses: ["dataclass"] },
+        })
+      ).toEqual(`from dataclasses import dataclass
+
+@dataclass(order=True)
+class Hello:
+    greeting: str`);
+    });
+
+    it(`Imports and displays them based on name`, async (): Promise<void> => {
+      const input = `
+    type Hello {
+      greeting: String!
+    }
+`;
+
+      const schema = makeExecutableSchema({ typeDefs: input });
+
+      expect(
+        python.fromSchema(schema, {
+          decorators: ["dataclass"],
+          extraImports: { dataclasses: ["dataclass"] },
+        })
+      ).toEqual(`from dataclasses import dataclass
+
+@dataclass
+class Hello:
+    greeting: str`);
+    });
+  });
+
   describe("extraTypes", (): void => {
     it("treats as identifier when not specified", async (): Promise<void> => {
       const input = `


### PR DESCRIPTION
**Why** is the change needed?

In case someone wants to use (for example) dataclasses.
